### PR TITLE
fix: 기수 선택 드롭다운 안 열리는 이슈

### DIFF
--- a/components/Member/Board/Filter/Filter.tsx
+++ b/components/Member/Board/Filter/Filter.tsx
@@ -18,6 +18,7 @@ function CheckBoxFilter({
   setSelectedOptions,
 }: CheckBoxFilterProps) {
   const [allSelected, setAllSelected] = useState(true);
+
   function handleClickAllOption(e: React.MouseEvent) {
     e.preventDefault();
     const newSelectedOptions = options.map(() => !allSelected);
@@ -99,8 +100,8 @@ function SelectFilter({
     setFilterIsOpen(false);
   }
 
-  function handleClickFilter(e: React.MouseEvent) {
-    e.stopPropagation();
+  function handleClickFilter(e: React.MouseEvent<HTMLDivElement>) {
+    e.nativeEvent.stopImmediatePropagation();
     setFilterIsOpen(!filterIsOpen);
   }
 
@@ -173,6 +174,7 @@ function ToggleFilter({
   function handleClickFilter() {
     setIsActive(!isActive);
   }
+
   return (
     <div className={cx("container", "toggle")}>
       <label className={cx("filterName")}>{name}</label>

--- a/components/Member/Board/MemberCard/MemberCard.module.scss
+++ b/components/Member/Board/MemberCard/MemberCard.module.scss
@@ -154,7 +154,7 @@
   }
 }
 
-@container main-container (max-width: 400px) {
+@container main-container (max-width: 360px) {
   .container {
     .profile {
       .nameAndLink {


### PR DESCRIPTION
## 태스크 URL
https://www.notion.so/wafflestudio/49d18117949f4387a316dd6dd5e4fe12?p=595c8e83b833465ca59138f0d686a482&pm=s

## PR 체크리스트
- [x] pre-commit 성공 여부
- [x] Type label 추가


## Merge 체크리스트
- [ ] Squash & Merge
- [ ] 노션 태스크 완료 처리
- [ ] 이슈 코멘트 resolve


## 설명
next 13 업그레이드 후 드롭다운 안 켜지는 이슈 수정하였습니다.
원인은 `event.stopPropagation()` 이 적용되지 않는 게 이슈였고, `event.nativeEvent.stopImmediatePropagation()` 으로 해결하였습니다.