### PR TITLE
Fix: 멤버 카드 툴팁 버그 수정

### DIFF
--- a/components/Member/Board/Board.module.scss
+++ b/components/Member/Board/Board.module.scss
@@ -99,18 +99,18 @@
       &.top {
         top: 0;
         background: linear-gradient(
-            180deg,
-            rgba(138, 138, 138, 0.09) 0%,
-            rgba(255, 255, 255, 0) 77%
+          180deg,
+          rgba(138, 138, 138, 0.09) 0%,
+          rgba(255, 255, 255, 0) 77%
         );
       }
 
       &.bottom {
         bottom: 0;
         background: linear-gradient(
-            180deg,
-            rgba(255, 255, 255, 0) 23%,
-            rgba(138, 138, 138, 0.09) 100%
+          180deg,
+          rgba(255, 255, 255, 0) 23%,
+          rgba(138, 138, 138, 0.09) 100%
         );
       }
     }
@@ -153,8 +153,11 @@
       display: none;
     }
   }
-}
 
+  .memberCardWrapper {
+    flex: 1 0 45vw;
+  }
+}
 
 @include responsive.mobile {
   .container {
@@ -175,5 +178,9 @@
         }
       }
     }
+  }
+
+  .memberCardWrapper {
+    flex: 1 0 80vw;
   }
 }

--- a/components/Member/Board/MemberCard/MemberCard.module.scss
+++ b/components/Member/Board/MemberCard/MemberCard.module.scss
@@ -3,8 +3,11 @@
 
 .helper {
   position: fixed;
+  top: 0;
+  left: 0;
+  transform: translate(0, 0);
   z-index: 100;
-  display: flex;
+  display: none;
   flex-direction: row;
   align-items: center;
   height: 25px;
@@ -19,6 +22,7 @@
   background: var(--background-color);
   color: var(--text-color);
   opacity: 0;
+  cursor: default;
 }
 
 .container {
@@ -26,7 +30,7 @@
   @include position.flex(row, center, stretch);
   width: 100%;
   aspect-ratio: 412 / 152 !important;
-  border: 1px solid #C4C4C4;
+  border: 1px solid #c4c4c4;
   border-radius: 10px;
   padding: 4.6%;
   gap: 6.8%;
@@ -56,6 +60,7 @@
     }
 
     &:hover .helper {
+      display: flex;
       transition: opacity 0.3s;
       opacity: 1;
     }
@@ -99,6 +104,7 @@
         height: 23px;
 
         &:hover .helper {
+          display: flex;
           transition: opacity 0.3s;
           opacity: 1;
           --background-color: rgba(224, 224, 224, 0.9);

--- a/components/Member/Board/MemberCard/MemberCard.tsx
+++ b/components/Member/Board/MemberCard/MemberCard.tsx
@@ -33,6 +33,7 @@ function MemberCard({
     roles.filter((role) => role === "운영팀").length > 0 ? 2 : 1;
   const [hoverTags, setHoverTags] = useState(false);
   const helper = useRef<HTMLDivElement | null>(null);
+  const container = useRef<HTMLDivElement | null>(null);
 
   function handleMouseEnterTags() {
     if (roles.length > positionShownCount) setHoverTags(true);
@@ -43,15 +44,17 @@ function MemberCard({
   }
 
   function handleMouseMoveHelper(e: React.MouseEvent<HTMLElement>) {
-    if (e.currentTarget.lastChild) {
+    if (e.currentTarget.lastChild && container.current) {
+      const rect = container.current.getBoundingClientRect();
       const helper = e.currentTarget.lastChild as HTMLElement;
-      helper.style.left = `${e.clientX}px`;
-      helper.style.top = `${e.clientY - 25}px`;
+      helper.style.transform = `translate(${e.clientX - rect.x + 10}px, ${
+        e.clientY - rect.y - 30
+      }px)`;
     }
   }
 
   return (
-    <div className={cx("container")}>
+    <div className={cx("container")} ref={container}>
       <div
         className={cx("profileImageAndBadge", isActive ? "active" : "inactive")}
         onMouseMove={handleMouseMoveHelper}


### PR DESCRIPTION
## 태스크 URL
<!--
노션 이슈트래킹 페이지에서 관련 이슈의 링크를 적어주세요
Example
[식샤 서비스 소개 페이지 개발](https://www.notion.so/wafflestudio/81db745055074db1abc0fc7deccccf80)
-->


## PR 체크리스트
- [x] pre-commit 성공 여부
- [x] Type label 추가


## Merge 체크리스트
- [ ] Squash & Merge
- [ ] 노션 태스크 완료 처리
- [ ] 이슈 코멘트 resolve


## 설명
* 멤버 카드들이 데스크탑, 태블릿, 모바일 사이즈에서 각각 3줄, 2줄, 1줄로 고정되도록 변경했습니다
* 툴팁이 이상한 위치에서 나타나는 버그를 수정했습니다.
  * 컨테이너 쿼리 관련 이슈였는데, 컨테이너 쿼리 사용 시 자식 요소들에 `fixed` 포지션이 제대로 작동하지 않아 `translate` 로 움직이도록 변경했습니다.
* 툴팁이 마우스가 있는 장치에서만 나타나도록 미디어 쿼리를 추가했습니다. (태블릿, 모바일 등에선 이제 안 나타남)