### PR TITLE
Feat/ 홈 탭 캐러셀 개선

### DIFF
--- a/components/Home/Activity/Carousel.module.scss
+++ b/components/Home/Activity/Carousel.module.scss
@@ -94,7 +94,7 @@ $carousel-length: 5;
     .dot {
       width: 0.8em;
       height: 0.8em;
-      border-radius: 100%;
+      border-radius: 0.4em;
       background-color: #e7e7e7;
       transition: 0.2s;
     }

--- a/components/Home/Activity/Carousel.module.scss
+++ b/components/Home/Activity/Carousel.module.scss
@@ -21,6 +21,7 @@ $carousel-length: 5;
         gap: 5vw;
         overflow-x: scroll;
         scroll-snap-type: x mandatory;
+        cursor: grab;
 
         // 처음과 마지막 캐러셀 콘텐츠의 가운데 정렬을 맞추기 위한 가상요소
         &::before {

--- a/components/Home/Activity/Carousel.tsx
+++ b/components/Home/Activity/Carousel.tsx
@@ -20,11 +20,36 @@ export default function Carousel({
 
   const carouselScrollHandler = useCallback(
     (e: React.MouseEvent<HTMLDivElement>) => {
+      console.log(e.type);
       const stride = window.innerWidth * 0.85;
       setSelectedId(Math.round(e.currentTarget.scrollLeft / stride));
     },
     [setSelectedId],
   );
+
+  const carouselMouseDownHandler = (e: React.MouseEvent<HTMLDivElement>) => {
+    e.currentTarget.style.cursor = "grabbing";
+    e.currentTarget.style.scrollSnapType = "none";
+  };
+
+  const carouselMouseMoveHandler = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (e.currentTarget.style.cursor === "grabbing") {
+      e.currentTarget.scrollLeft -= e.movementX;
+    }
+  };
+
+  const carouselMouseUpHandler = (e: React.MouseEvent<HTMLDivElement>) => {
+    e.currentTarget.style.cursor = "grab";
+    const stride = window.innerWidth * 0.85;
+    e.currentTarget.scrollTo({
+      left: selectedId * stride,
+      behavior: "smooth",
+    });
+    const target = e.currentTarget;
+    setTimeout(() => {
+      target.style.scrollSnapType = "x mandatory";
+    }, 400);
+  };
 
   const indicatorClickHandler = (id: number) => () => {
     carouselRef.current?.scrollTo({
@@ -40,7 +65,11 @@ export default function Carousel({
           <div
             className={cx("carouselItemsContainer")}
             onScroll={carouselScrollHandler}
+            onMouseDown={carouselMouseDownHandler}
+            onMouseMove={carouselMouseMoveHandler}
+            onMouseUp={carouselMouseUpHandler}
             ref={carouselRef}
+            draggable={false}
           >
             {activities.map((activity, id) => (
               <CarouselItem key={id} activity={activity} />
@@ -70,7 +99,7 @@ function CarouselItem({ activity }: CarouselItemProps) {
   return (
     <div className={cx("carouselItem")}>
       <div className={cx("imageContainer")}>
-        <img src={activity.image} alt={activity.altText} />
+        <img src={activity.image} alt={activity.altText} draggable={false} />
       </div>
       <div className={cx("textContainer")}>
         <h1 className={cx("activityTitle")}>{activity.head}</h1>

--- a/components/Home/Activity/Carousel.tsx
+++ b/components/Home/Activity/Carousel.tsx
@@ -17,6 +17,7 @@ export default function Carousel({
   setSelectedId,
 }: CarouselProps) {
   const carouselRef = useRef<HTMLDivElement>(null);
+  const scrollSnapTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 
   const carouselScrollHandler = useCallback(
     (e: React.MouseEvent<HTMLDivElement>) => {
@@ -30,6 +31,9 @@ export default function Carousel({
   const carouselMouseDownHandler = (e: React.MouseEvent<HTMLDivElement>) => {
     e.currentTarget.style.cursor = "grabbing";
     e.currentTarget.style.scrollSnapType = "none";
+    if (scrollSnapTimeoutRef.current) {
+      clearTimeout(scrollSnapTimeoutRef.current);
+    }
   };
 
   const carouselMouseMoveHandler = (e: React.MouseEvent<HTMLDivElement>) => {
@@ -46,7 +50,7 @@ export default function Carousel({
       behavior: "smooth",
     });
     const target = e.currentTarget;
-    setTimeout(() => {
+    scrollSnapTimeoutRef.current = setTimeout(() => {
       target.style.scrollSnapType = "x mandatory";
     }, 400);
   };

--- a/components/Home/Activity/Carousel.tsx
+++ b/components/Home/Activity/Carousel.tsx
@@ -1,5 +1,5 @@
 import classNames from "classnames/bind";
-import { useCallback, useMemo } from "react";
+import { useCallback, useRef } from "react";
 import styles from "./Carousel.module.scss";
 import { ActivityData } from "./ActivityData";
 
@@ -16,13 +16,22 @@ export default function Carousel({
   selectedId,
   setSelectedId,
 }: CarouselProps) {
+  const carouselRef = useRef<HTMLDivElement>(null);
+
   const carouselScrollHandler = useCallback(
     (e: React.MouseEvent<HTMLDivElement>) => {
       const stride = window.innerWidth * 0.85;
       setSelectedId(Math.round(e.currentTarget.scrollLeft / stride));
     },
-    [],
+    [setSelectedId],
   );
+
+  const indicatorClickHandler = (id: number) => () => {
+    carouselRef.current?.scrollTo({
+      left: (id * carouselRef.current.scrollWidth) / activities.length,
+      behavior: "smooth",
+    });
+  };
 
   return (
     <>
@@ -31,6 +40,7 @@ export default function Carousel({
           <div
             className={cx("carouselItemsContainer")}
             onScroll={carouselScrollHandler}
+            ref={carouselRef}
           >
             {activities.map((activity, id) => (
               <CarouselItem key={id} activity={activity} />
@@ -40,10 +50,11 @@ export default function Carousel({
       </div>
 
       <ul className={cx("carouselIndicator")}>
-        {[0, 1, 2, 3, 4].map((id) => (
+        {activities.map((activity, id) => (
           <div
             key={id}
             className={cx("dot", id === selectedId ? "selected" : "")}
+            onClick={indicatorClickHandler(id)}
           />
         ))}
       </ul>


### PR DESCRIPTION
## 태스크 URL
<!--
노션 이슈트래킹 페이지에서 관련 이슈의 링크를 적어주세요
Example
[식샤 서비스 소개 페이지 개발](https://www.notion.so/wafflestudio/81db745055074db1abc0fc7deccccf80)
-->


## PR 체크리스트
- [x] pre-commit 성공 여부
- [x] Type label 추가


## Merge 체크리스트
- [ ] Squash & Merge
- [ ] 노션 태스크 완료 처리
- [ ] 이슈 코멘트 resolve


## 설명
1. 캐러셀 인디케이터 변화할 때 `border-radius` 가 %로 적용되어 있어서 순간적으로 타원형으로 보이던 이슈 수정
2. 인디케이터 클릭 시 캐러셀 이동하는 기능 추가
3. 마우스 드래그 시 좌우 스크롤되도록 변경

## 테스트 방법 (Optional)


## 기타 질문 및 공유 사항 (Optional)
