### PR TITLE
Fix/member/number of member

### DIFF
--- a/components/Member/Board/Board.module.scss
+++ b/components/Member/Board/Board.module.scss
@@ -126,7 +126,7 @@
 }
 
 .memberCardWrapper {
-  flex: 1 0 350px;
+  width: calc((100% - 40px) / 3);
 }
 
 @include responsive.tabletAndMobile {
@@ -144,7 +144,6 @@
 
         .cardContainer {
           width: 100%;
-          justify-content: center;
         }
       }
     }
@@ -155,7 +154,7 @@
   }
 
   .memberCardWrapper {
-    flex: 1 0 45vw;
+    width: calc((100% - 20px) / 2);
   }
 }
 

--- a/components/Member/Board/Board.tsx
+++ b/components/Member/Board/Board.tsx
@@ -112,7 +112,7 @@ function Board() {
         <div className={cx("description")}>
           <span>현재까지</span>
           <span className={cx("numberOfMembers")}>
-            <CountingNumber targetNum={members.length} />
+            <CountingNumber targetNum={327} />
           </span>
           <span>명이 와플스튜디오에 함께했습니다.</span>
         </div>


### PR DESCRIPTION
## 태스크 URL
<!--
노션 이슈트래킹 페이지에서 관련 이슈의 링크를 적어주세요
Example
[식샤 서비스 소개 페이지 개발](https://www.notion.so/wafflestudio/81db745055074db1abc0fc7deccccf80)
-->


## PR 체크리스트
- [x] pre-commit 성공 여부
- [x] Type label 추가


## Merge 체크리스트
- [x] Squash & Merge
- [ ] 노션 태스크 완료 처리
- [ ] 이슈 코멘트 resolve


## 설명
1. 멤버 수가 너무 적어보여서 디비에 있는 숫자만 임시로 반영하여 327명으로 늘렸습니다.
2. 멤버 탭에서 마지막 줄에 멤버 카드가 한 줄을 다 채우지 못했을 때 너비가 늘어나는 이슈를 수정했습니다.